### PR TITLE
Sweep function, first implementation

### DIFF
--- a/Test/generate/generate.c
+++ b/Test/generate/generate.c
@@ -1,5 +1,5 @@
 /**
- * $Id: generate_sweep.c 1246 2014-06-02 09:07am pdorazio $
+ * $Id: generate.c 1246 2014-06-02 09:07am pdorazio $
  *
  * @brief Red Pitaya simple signal/function generator with pre-defined
  *        signal types.


### PR DESCRIPTION
Adds a new option to the generate command. Using sweep argument and end frequency, the Pitaya can now generate a looped frequency sweep. Loop length determined by size of data buffer, n = 16*1024. Usage:

generate <channel> <amplitude> <start frequency> sweep <end frequency>
