### PR TITLE
Update rcS to catch SD mount failure

### DIFF
--- a/OS/buildroot/overlay/etc/init.d/rcS
+++ b/OS/buildroot/overlay/etc/init.d/rcS
@@ -8,6 +8,12 @@ mkdir -p /dev/pts
 mkdir -p /dev/i2c
 mount -a
 
+# Check if SD card mounted, if not wait and try again
+if ! grep -qs '/opt' /proc/mounts; then
+	sleep 1
+	mount -a
+fi
+
 # Create /tmp structure every time, since it resides in RAM
 mkdir -p /tmp/log/nginx
 


### PR DESCRIPTION
My RedPitaya fails to mount /opt because /dev/mmcblk0p1 isn't ready yet. Add a retry with a short delay to catch this.
