### PR TITLE
Typo in rp_DpinSetDirection

### DIFF
--- a/api/rpbase/src/rp.c
+++ b/api/rpbase/src/rp.c
@@ -282,7 +282,7 @@ int rp_DpinSetDirection(rp_dpin_t pin, rp_pinDirection_t direction) {
         // DIO_N
         pin -= RP_DIO0_N;
         tmp = ioread32(&hk->ex_cd_n);
-        iowrite32((tmp & ~(1 << pin)) | ((direction << pin) & (1 << pin)), &hk->ex_cd_p);
+        iowrite32((tmp & ~(1 << pin)) | ((direction << pin) & (1 << pin)), &hk->ex_cd_n);
     }
     return RP_OK;
 }


### PR DESCRIPTION
SetDirection on DIO0_N -> ex_cd_n, not ex_cd_p.