### PR TITLE
new function: InitWithoutReset

### DIFF
--- a/api/include/redpitaya/rp.h
+++ b/api/include/redpitaya/rp.h
@@ -267,6 +267,13 @@ typedef struct wf_func_table_t {
  */
 int rp_Init();
 
+/**
+ * Initializes the library. same as rp_Init but without reseting all modules.
+ * @return If the function is successful, the return value is RP_OK.
+ * If the function is unsuccessful, the return value is any of RP_E* values that indicate an error.
+ */
+int rp_InitWithoutReset();
+
 int rp_CalibInit();
 
 /**

--- a/api/rpbase/src/rp.c
+++ b/api/rpbase/src/rp.c
@@ -48,6 +48,20 @@ int rp_Init()
     return RP_OK;
 }
 
+int rp_InitWithoutReset()
+{
+    ECHECK(cmn_Init());
+    
+    ECHECK(calib_Init());
+    ECHECK(hk_Init());
+    ECHECK(ams_Init());
+    ECHECK(generate_Init());
+    ECHECK(osc_Init());
+    // TODO: Place other module initializations here
+
+    return RP_OK;
+}
+
 int rp_CalibInit()
 {
     ECHECK(calib_Init());


### PR DESCRIPTION
The problem we had was that we are using librp for different applications (executables); each of them focusing on one module (e.g. osc, AO etc). But each time we run one app it would reset other modules.
rp_Init needs to be called because it sets module level variables, but reset can be called for each module that is being used.

Alternatively; we could just add a parameter to init (bool reset) but C doesn't support default arguments so that breaks backward compatibility and I don't know how many people use the api and don't want to change their code.
