### PR TITLE
SPI: use the right spi bus number in devicetree

### DIFF
--- a/patches/devicetree.patch
+++ b/patches/devicetree.patch
@@ -73,10 +73,10 @@
 +	    };
 +	};
 +};
-+&spi0 {
++&spi1 {
 +	spidev@0 {
-+		compatible="spidev";
-+		reg =<0>; //chipselect 0
-+		spi-max-frequency= <50000000>;
++		compatible = "spidev";
++		reg = <0>; //chipselect 0
++		spi-max-frequency = <50000000>;
 +	};
 +};


### PR DESCRIPTION
Didn't test it because I don't have enough space for another Vivado installation in my VM, but it's fairly obvious. 