### PR TITLE
Fix API library not used by linker error

### DIFF
--- a/Examples/C/Makefile
+++ b/Examples/C/Makefile
@@ -3,7 +3,8 @@ CC = $(CROSS_COMPILE)gcc
 
 CFLAGS  = -g -std=gnu99 -Wall -Werror
 CFLAGS += -I../../api/include
-CFLAGS += -L ../../api/lib -lm -lpthread -lrp
+LDFLAGS = -L../../api/lib
+LDLIBS = -lm -lpthread -lrp
 
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=)


### PR DESCRIPTION
The Makefile is creating binaries via GNU Make's built in targets. The libraries were not being included in the correct order (after the C source). As a result the linker fails:

~/RedPitaya/Examples/C# make clean
rm -f *.o
rm -f test_e_module digital_led_bar generate_burst_trigger_external generate_burst_trigger_software analog_outputs acquire_trigger_posedge generate_arbitrary_waveform acquire_trigger_software digital_push_button generate_continuous digital_led_blink analog_inputs
root@rp-f01fbf:~/RedPitaya/Examples/C# make
gcc -g -std=gnu99 -Wall -Werror -I../../api/include -L ../../api/lib -lm -lpthread -lrp    test_e_module.c   -o test_e_module
gcc -g -std=gnu99 -Wall -Werror -I../../api/include -L ../../api/lib -lm -lpthread -lrp    digital_led_bar.c   -o digital_led_bar
/tmp/ccU5OOh5.o: In function `main':
/root/RedPitaya/Examples/C/digital_led_bar.c:19: undefined reference to `rp_Init'
/root/RedPitaya/Examples/C/digital_led_bar.c:27: undefined reference to `rp_DpinSetState'
/root/RedPitaya/Examples/C/digital_led_bar.c:29: undefined reference to `rp_DpinSetState'
/root/RedPitaya/Examples/C/digital_led_bar.c:34: undefined reference to `rp_Release'
collect2: error: ld returned 1 exit status
<builtin>: recipe for target 'digital_led_bar' failed
make: *** [digital_led_bar] Error 1

By using the LD flags the order of files seen by the linker changes and symbols get resolved.

~/RedPitaya/Examples/C# make
gcc -g -std=gnu99 -Wall -Werror -I../../api/include  -L../../api/lib  test_e_module.c  -lm -lpthread -lrp -o test_e_module
gcc -g -std=gnu99 -Wall -Werror -I../../api/include  -L../../api/lib  digital_led_bar.c  -lm -lpthread -lrp -o digital_led_bar
gcc -g -std=gnu99 -Wall -Werror -I../../api/include  -L../../api/lib  generate_burst_trigger_external.c  -lm -lpthread -lrp -o generate_burst_trigger_external
gcc -g -std=gnu99 -Wall -Werror -I../../api/include  -L../../api/lib  generate_burst_trigger_software.c  -lm -lpthread -lrp -o generate_burst_trigger_software
gcc -g -std=gnu99 -Wall -Werror -I../../api/include  -L../../api/lib  analog_outputs.c  -lm -lpthread -lrp -o analog_outputs
gcc -g -std=gnu99 -Wall -Werror -I../../api/include  -L../../api/lib  acquire_trigger_posedge.c  -lm -lpthread -lrp -o acquire_trigger_posedge
gcc -g -std=gnu99 -Wall -Werror -I../../api/include  -L../../api/lib  generate_arbitrary_waveform.c  -lm -lpthread -lrp -o generate_arbitrary_waveform
gcc -g -std=gnu99 -Wall -Werror -I../../api/include  -L../../api/lib  acquire_trigger_software.c  -lm -lpthread -lrp -o acquire_trigger_software
gcc -g -std=gnu99 -Wall -Werror -I../../api/include  -L../../api/lib  digital_push_button.c  -lm -lpthread -lrp -o digital_push_button
gcc -g -std=gnu99 -Wall -Werror -I../../api/include  -L../../api/lib  generate_continuous.c  -lm -lpthread -lrp -o generate_continuous
gcc -g -std=gnu99 -Wall -Werror -I../../api/include  -L../../api/lib  digital_led_blink.c  -lm -lpthread -lrp -o digital_led_blink
gcc -g -std=gnu99 -Wall -Werror -I../../api/include  -L../../api/lib  analog_inputs.c  -lm -lpthread -lrp -o analog_inputs