### PR TITLE
Simplify reconfiguring the kernel and building kernel modules

### DIFF
--- a/Makefile.x86
+++ b/Makefile.x86
@@ -132,8 +132,9 @@ $(UBOOT_SCRIPT): $(INSTALL_DIR) $(UBOOT_DIR) $(UBOOT)
 ################################################################################
 
 LINUX = $(LINUX_DIR)/arch/arm/boot/uImage
+LINUX_CONFIG = $(LINUX_DIR)/.config
 
-.PHONY: linux linux-install
+.PHONY: linux linux-config linux-menuconfig linux-install
 
 linux: $(LINUX)
 
@@ -159,13 +160,21 @@ $(LINUX_DIR): $(LINUX_TAR)
 	cp -r patches/rtl8192cu $@/drivers/net/wireless/
 	patch -d $@ -p 1 < patches/linux-xlnx-$(LINUX_TAG)-wifi.patch
 
-$(LINUX): $(LINUX_DIR)
+$(LINUX_CONFIG): $(LINUX_DIR)
 	make -C $< mrproper
 	make -C $< ARCH=arm xilinx_zynq_defconfig
-	make -C $< ARCH=arm CFLAGS=$(LINUX_CFLAGS) -j $(shell grep -c ^processor /proc/cpuinfo) UIMAGE_LOADADDR=0x8000 uImage
+
+$(LINUX): $(LINUX_CONFIG)
+	make -C $(LINUX_DIR) ARCH=arm CFLAGS=$(LINUX_CFLAGS) -j $(shell grep -c ^processor /proc/cpuinfo) UIMAGE_LOADADDR=0x8000 uImage modules
+
+linux-config: $(LINUX_CONFIG)
+
+linux-menuconfig: $(LINUX_CONFIG)
+	make -C $(LINUX_DIR) ARCH=arm menuconfig
 
 linux-install: linux $(INSTALL_DIR)
 	cp $(LINUX_DIR)/arch/arm/boot/uImage $(INSTALL_DIR)
+	make -C $(LINUX_DIR) ARCH=arm CFLAGS=$(LINUX_CFLAGS) INSTALL_MOD_PATH=$(abspath $(INSTALL_DIR)) modules_install
 
 ################################################################################
 # device tree processing


### PR DESCRIPTION
Make it easier for users to reconfigure the kernel and build kernel modules.

This splits the kernel build workflow and adds two new targets:

* linux-config: Generate the initial kernel configuration
* linux-menuconfig: Run the kernel configuration menu using the current (or default) configuration.

The proposed change should not affect the normal workflow:
```sh
$ make -f Makefile.x86 linux-install
```
should continue to work as usual.

Additional workflows:
* Reconfigure, build and install the kernel:
```sh
$ make -f Makefile.x86 linux-menuconfig
$ make -f Makefile.x86 linux-install
```
* Apply a custom configuration, build and install the kernel:
```sh
$ make -f Makefile.x86 linux-config
$ cp custom-config tmp/<path-to-kernel-source>/.config
$ make -f Makefile.x86 linux-install
```

The proposed change also installs any built kernel modules into the directory `build/lib/modules`. To use the modules, I think that copying the contents of the `build` directory to the ecosystem partition and adding a symlink `/lib/modules -> /opt/redpitaya/lib/modules` in the OS filesystem should be enough, but I haven't tested this yet (I'm waiting for my colleague to relinquish our Red Pitaya after he has finished his project).