### PR TITLE
dmaDrv buffer length misplaced

### DIFF
--- a/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/src/rp_bazaar_cmd.c
+++ b/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/src/rp_bazaar_cmd.c
@@ -482,8 +482,8 @@ int rp_bazaar_start(ngx_http_request_t *r,
             case FPGA_OK:
             {
                 if (fpga_name)  free(fpga_name);
-                char dmaDrv[len];
                 len = strlen((char *)lc->bazaar_dir.data) + strlen(argv[0]) + strlen("/fpga.sh") + 2;
+                char dmaDrv[len];
                 sprintf(dmaDrv, "%s/%s/fpga.sh", lc->bazaar_dir.data, argv[0]);
                 if (system(dmaDrv))
                     fprintf(stderr, "Problem running %s\n", dmaDrv);


### PR DESCRIPTION
Hello,
I believe there was a typo:
`len = ...` calculation after `dmaDrv[len]` initialization
Cheers,
Ilja