### PR TITLE
Little fix for error message in redpitaya_scpi.py

### DIFF
--- a/Examples/python/redpitaya_scpi.py
+++ b/Examples/python/redpitaya_scpi.py
@@ -26,7 +26,7 @@ class scpi (object):
             self._socket.connect((host, port))
 
         except socket.error as e:
-            print('SCPI >> connect({:s}:{:d}) failed: {:s}'.format(host, port, e))
+            print('SCPI >> connect({:s}:{:d}) failed: {:s}'.format(host, port, str(e)))
 
     def rx_txt(self, chunksize = 4096):
         """Receive text string and return it after removing the delimiter."""


### PR DESCRIPTION
Application crashes with TypeError: unsupported format string passed to ConnectionRefusedError.__format__ 
the fix is to use `str(e)` instead of `e`