### PR TITLE
API:gen_setFrequency: major speedup if waveform does not depend on frequency

### DIFF
--- a/api/src/gen_handler.c
+++ b/api/src/gen_handler.c
@@ -123,20 +123,25 @@ int gen_setFrequency(rp_channel_t channel, float frequency) {
         return RP_EOOR;
     }
 
+    rp_waveform_t waveform;
     if (channel == RP_CH_1) {
         chA_frequency = frequency;
         gen_setBurstPeriod(channel, chA_burstPeriod);
+        waveform = chA_waveform;
     }
     else if (channel == RP_CH_2) {
         chB_frequency = frequency;
         gen_setBurstPeriod(channel, chB_burstPeriod);
+        waveform = chB_waveform;
     }
     else {
         return RP_EPN;
     }
 
     generate_setFrequency(channel, frequency);
-    synthesize_signal(channel);
+    if (waveform == RP_WAVEFORM_SQUARE) {
+      synthesize_signal(channel);
+    }
     return gen_Synchronise();
 }
 


### PR DESCRIPTION
rp_GenFreq() usually takes about 10ms because it synthesizes the signal. Now it only synthesizes it for SquareWave as it is the only one depending on it.
rp_GenFreq() now takes around 0.2ms for all other waveforms.