### PR TITLE
Include api2 as part of target all in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ export VERSION
 #
 ################################################################################
 
-all:  sdr api nginx scpi examples rp_communication apps-tools apps-pro apps-free-vna
+all:  sdr api api2 nginx scpi examples rp_communication apps-tools apps-pro apps-free-vna
 
 $(DL):
 	mkdir -p $@


### PR DESCRIPTION
stemlab_vna does not build reporting missing library rp2....
adding api2 as part of the all target builds the library that is needed.