### PR TITLE
fixed definition of the board path in tcl script -

### DIFF
--- a/fpga/red_pitaya_vivado_project_Z10.tcl
+++ b/fpga/red_pitaya_vivado_project_Z10.tcl
@@ -11,7 +11,7 @@ cd prj/$::argv
 # define paths
 ################################################################################
 
-set path_brd brd
+set path_brd ../../brd
 set path_rtl rtl
 set path_ip  ip
 set path_sdc sdc

--- a/fpga/red_pitaya_vivado_project_Z20.tcl
+++ b/fpga/red_pitaya_vivado_project_Z20.tcl
@@ -11,7 +11,7 @@ cd prj/$::argv
 # define paths
 ################################################################################
 
-set path_brd brd
+set path_brd ../../brd
 set path_rtl rtl
 set path_ip  ip
 set path_sdc sdc


### PR DESCRIPTION
 it is currently stored indeendenly to projects and not in /prj folder