### PR TITLE
Use power of 2, check `msg` for delimiter

### DIFF
--- a/Examples/python/redpitaya_scpi.py
+++ b/Examples/python/redpitaya_scpi.py
@@ -41,11 +41,14 @@ class scpi (object):
         """Receive text string and return it after removing the delimiter."""
         msg = ''
         while 1:
-            chunk = self._socket.recv(chunksize + len(self.delimiter)).decode('utf-8') # Receive chunk size of 2^n preferably
+            chunk = self._socket.recv(chunksize).decode('utf-8') # Receive chunk size of 2^n preferably
             msg += chunk
-            if (len(chunk) and chunk[-2:] == self.delimiter):
+            if (len(msg) and msg[-2:] == self.delimiter):
+                msg = msg[-2:]
                 break
-        return msg[:-2]
+            if len(chunk) < chunksize:
+                break
+        return msg
 
     def rx_arb(self):
         numOfBytes = 0

--- a/Examples/python/redpitaya_scpi.py
+++ b/Examples/python/redpitaya_scpi.py
@@ -44,9 +44,8 @@ class scpi (object):
             chunk = self._socket.recv(chunksize).decode('utf-8') # Receive chunk size of 2^n preferably
             msg += chunk
             if (len(msg) and msg[-2:] == self.delimiter):
-                msg = msg[:-2]
                 break
-        return msg
+        return msg[:-2]
 
     def rx_arb(self):
         numOfBytes = 0

--- a/Examples/python/redpitaya_scpi.py
+++ b/Examples/python/redpitaya_scpi.py
@@ -44,9 +44,7 @@ class scpi (object):
             chunk = self._socket.recv(chunksize).decode('utf-8') # Receive chunk size of 2^n preferably
             msg += chunk
             if (len(msg) and msg[-2:] == self.delimiter):
-                msg = msg[-2:]
-                break
-            if len(chunk) < chunksize:
+                msg = msg[:-2]
                 break
         return msg
 


### PR DESCRIPTION
Stop adding the length of the delimiter to chunksize. For efficiency
chunksize needs to be a power of two and adding the delimiter made it no
longer a power of two. Also, there is no need to add space for the
delimiter. If the delimiter does not happen to fit in the current chunk
then it will be read in a subsequent read.

When checking whether the delimiter has been seen, stop looking at
chunk. Instead, look at msg. It could be the case that the message
length (without the delimiter) was one smaller than the buffer length.
This means that the delimiter would be split over two chunks and testing
chunk to see if it was terminated would fail. Test the msg instead.