### PR TITLE
Import the pyvisa package

### DIFF
--- a/Examples/python/identification.py
+++ b/Examples/python/identification.py
@@ -11,9 +11,9 @@ args = parser.parse_args()
 # connect to the instrument
 ###############################################################################
 
-import visa
+import pyvisa
 
-rm = visa.ResourceManager('@py')
+rm = pyvisa.ResourceManager('@py')
 #rm.list_resources()
 rp = rm.open_resource('TCPIP::{}::{}::SOCKET'.format(args.adr, args.port), read_termination = '\r\n')
 


### PR DESCRIPTION
The desired API comes from the `pyvisa` package, not the `visa` package. Update the example to import `pyvisa` instead. See the Red Pitaya Python installation instructions:

https://github.com/RedPitaya/Documentation/blame/d6a87cdfd695095f2e63e1902c532cae33b324c4/appsFeatures/remoteControl/remoteControl.rst#L82-L88
