### PR TITLE
Make *rx_buffer const

### DIFF
--- a/Examples/C/spi_loopback.c
+++ b/Examples/C/spi_loopback.c
@@ -22,10 +22,10 @@ int main(int argc, char *argv[]){
 
     int res = rp_SPI_InitDevice("/dev/spidev1.0"); // Init spi api.
     printf("Init result: %d\n",res);
-    
+
     res = rp_SPI_SetDefaultSettings(); // Set default settings.
     printf("Set default settings: %d\n",res);
-    
+
     res = rp_SPI_GetSettings(); // Get uart speed.
     printf("Get current settings of spi: %d\n",res);
 
@@ -49,17 +49,17 @@ int main(int argc, char *argv[]){
 
     res = rp_SPI_SetBufferForMessage(1,0,true,100,false); // Create RX buffer.
     printf("Set buffers for second msg: %d\n",res);
-    
+
     res = rp_SPI_ReadWrite(); // Pass message to SPI.
     printf("Read/Write to spi: %d\n",res);
 
-    uint8_t *rx_buffer = 0;
+    const uint8_t *rx_buffer = 0;
     size_t rx_size = 0;
-    res = rp_SPI_GetRxBuffer(0,&rx_buffer,&rx_size); // Get pointer to rx buffer. No need free buffer. Api itself destroy buffer. 
+    res = rp_SPI_GetRxBuffer(0,&rx_buffer,&rx_size); // Get pointer to rx buffer. No need free buffer. Api itself destroy buffer.
 
     if (rx_buffer)
         printf("Read message: %s (res %d)\n",rx_buffer,res);
-    
+
     res = rp_SPI_DestoryMessage();
 
     res = rp_SPI_Release(); // Close spi api.


### PR DESCRIPTION
The capp to rp_SPI_GetRxBuffer() expects the buffer to be const. Without
the const qualifier the code will not compile.

```
cc -g -std=gnu11 -Wall -Werror -I/opt/redpitaya/include -I/root/dev/RedPitaya/build/include  -L/opt/redpitaya/lib -L/root/dev/RedPitaya/build/lib  spi_loopback.c  -static -lrp-hw -lrp -lm -lstdc++ -lpthread -o spi_loopback
spi_loopback.c: In function ‘main’:
spi_loopback.c:58:32: error: passing argument 2 of ‘rp_SPI_GetRxBuffer’ from incompatible pointer type [-Werror=incompatible-pointer-types]
     res = rp_SPI_GetRxBuffer(0,&rx_buffer,&rx_size); // Get pointer to rx buffer. No need free buffer. Api itself destr
                                ^
In file included from spi_loopback.c:14:0:
/root/dev/RedPitaya/build/include/rp_hw.h:377:5: note: expected ‘const uint8_t ** {aka const unsigned char **}’ but argument is of type ‘uint8_t ** {aka unsigned char **}’
 int rp_SPI_GetRxBuffer(size_t msg,const uint8_t **buffer,size_t *len);
     ^
```

That the buffer needs to be const is shown in the `rp_hw.h` file:

```
int rp_SPI_GetRxBuffer(size_t msg,const uint8_t **buffer,size_t *len);
```

This pull request also cleans up a few extraneous spaces and adds a newline at the end of the file.