### PR TITLE
Add transmission delimiter to error message

### DIFF
--- a/scpi-server/src/scpi-commands.c
+++ b/scpi-server/src/scpi-commands.c
@@ -52,7 +52,7 @@ size_t SCPI_Write(scpi_t * context, const char * data, size_t len) {
                     len, written);
                 return total;
             }
-            
+
             len -= written;
             data += written;
             total += written;
@@ -66,7 +66,7 @@ scpi_result_t SCPI_Flush(scpi_t * context) {
 }
 
 int SCPI_Error(scpi_t * context, int_fast16_t err) {
-    const char error[] = "ERR!";
+    const char error[] = "ERR!\r\n";
     syslog(LOG_ERR, "**ERROR: %d, \"%s\"", (int32_t) err, SCPI_ErrorTranslate(err));
     SCPI_Write(context, error, strlen(error));
     return 0;
@@ -275,7 +275,7 @@ static const scpi_command_t scpi_commands[] = {
     {.pattern = "SPI:MSG#:CS?", .callback               = RP_SPI_GetCSChangeState,},
 
     {.pattern = "SPI:PASS", .callback                   = RP_SPI_Pass,},
-    
+
      /* i2c */
     {.pattern = "I2C:DEV#", .callback                  = RP_I2C_Dev,},
     {.pattern = "I2C:DEV?", .callback                  = RP_I2C_DevQ,},
@@ -296,7 +296,7 @@ static const scpi_command_t scpi_commands[] = {
     SCPI_CMD_LIST_END
 };
 
-static scpi_interface_t scpi_interface = {  
+static scpi_interface_t scpi_interface = {
     .error   = SCPI_Error,
     .write   = SCPI_Write,
     .control = SCPI_Control,
@@ -321,4 +321,3 @@ scpi_t scpi_context = {
     .units = scpi_units_def,
     .idn = {"REDPITAYA", "INSTR2020", NULL, "01-02"},
 };
-


### PR DESCRIPTION
The SCPI_Error() function writes an error message `ERR!` to the socket.
The calling program expects this message to be terminated with `\r\n`.
Since the message is not terminated, the calling program waits forever.

Add `\r\n` to the error message.

This pull request also cleans up a few extraneous spaces and adds a
newline at the end of the file.