### PR TITLE
Add back the missing 'a' in 'apt-get'

### DIFF
--- a/OS/debian/ubuntu.sh
+++ b/OS/debian/ubuntu.sh
@@ -7,7 +7,7 @@
 ################################################################################
 
 # Added by DM; 2017/10/17 to check ROOT_DIR setting
-if [ $ROOT_DIR ]; then 
+if [ $ROOT_DIR ]; then
     echo ROOT_DIR is "$ROOT_DIR"
 else
     echo Error: ROOT_DIR is not set
@@ -45,8 +45,8 @@ apt-get update
 apt-get -y upgrade
 apt-get install -y apt-utils
 
-# install HWE kernell
-pt-get -y install --install-recommends linux-tools-generic-hwe-16.04 linux-headers-generic-hwe-16.04
+# install HWE kernel
+apt-get -y install --install-recommends linux-tools-generic-hwe-16.04 linux-headers-generic-hwe-16.04
 
 # add package containing add-apt-repository
 apt-get -y install software-properties-common


### PR DESCRIPTION
It looks like the 'a' was dropped. Add it back. See original commit:

https://github.com/RedPitaya/RedPitaya/commit/fbda79e83e8281099049c7046cac1c53612404aa#diff-89cf1a725ab47e38b2aae0f95826a72b0b8e58662003d043b65c003d370c6fb8R49

Also fix a spelling error and remove some trailing whitespace.