### PR TITLE
Let doxygen build a complete API reference

### DIFF
--- a/rp-api/api/Doxyfile
+++ b/rp-api/api/Doxyfile
@@ -106,7 +106,7 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = include/redpitaya/rp.h
+INPUT                  = include/redpitaya
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.c \
                          *.cc \


### PR DESCRIPTION
The C API is defined in multiple header files, which reside in rp-api/api/include/redpitaya. These files carry doxygen comments, which enable the user to build the reference documentation by calling `doxygen` from the rp-api/api directory. The provided Doxyfile, however, instructs doxygen to process only the file rp.h, thus missing important parts of the public API. Notably, all function related to signal acquisition and generation are missing.

This pull request changes the Doxyfile in order to process all the API-defining header files, thus enabling the generation of a complete API reference.