### PR TITLE
Fix off-by-one error in acq_GetLatestDataV()

### DIFF
--- a/rp-api/api/src/acq_handler.c
+++ b/rp-api/api/src/acq_handler.c
@@ -1618,7 +1618,7 @@ int acq_GetLatestDataV(rp_channel_t channel, uint32_t* size, float* buffer)
     uint32_t pos;
     acq_GetWritePointer(&pos);
 
-    pos = (pos - (*size)) % ADC_BUFFER_SIZE;
+    pos = (pos + 1 - (*size)) % ADC_BUFFER_SIZE;
 
     return acq_GetDataV(channel, pos, size, buffer);
 }


### PR DESCRIPTION
The index returned by `acq_GetWritePointer()` is not the next array cell to be written to (as it would be in idiomatic C): it is instead the last cell that has already been written to. This is properly [accounted for in `acq_GetOldestDataV()`][oldest]:

```c
    acq_GetWritePointer(&pos);
    pos++;
```

However, `acq_GetLatestDataV()` does not account for this fact: it has an off-by-one error that makes it start reading one array cell too early, and thus miss the very last data point that has been acquired. The consequence of this error is mild most of the time: a 1-sample shift in the retrieved data. However, if one uses this function for retrieving the whole buffer, one gets a discontinuity between the first returned sample (which is the last one acquired) and the second returned sample (the first one acquired).

This pull request fixes this off-by-one error.

I tested the patch by running a version of the provided example `acquire_trigger_software.c`, modified in order to retrieve the whole buffer with `rp_AcqGetLatestDataV()`:

```diff
diff --git a/Examples/C/acquire_trigger_software.c b/Examples/C/acquire_trigger_software.c
index 5bd2d58..243129b 100644
--- a/Examples/C/acquire_trigger_software.c
+++ b/Examples/C/acquire_trigger_software.c
@@ -22,7 +22,7 @@ int main(int argc, char **argv){
         rp_GenOutEnable(RP_CH_1);
         rp_GenTriggerOnly(RP_CH_1);
 
-        uint32_t buff_size = 20;
+        uint32_t buff_size = ADC_BUFFER_SIZE;
         float *buff = (float *)malloc(buff_size * sizeof(float));
 
         rp_AcqReset();
@@ -65,7 +65,7 @@ int main(int argc, char **argv){
 
         rp_AcqStop();
 
-        rp_AcqGetOldestDataV(RP_CH_1, &buff_size, buff);
+        rp_AcqGetLatestDataV(RP_CH_1, &buff_size, buff);
 
         int i;
         for(i = 0; i < buff_size; i++){
```

The data printed by this example shows the mentioned discontinuity, which is removed by this patch.

[oldest]: ../blob/96b1b63a04f0/rp-api/api/src/acq_handler.c#L1605-L1606