### PR TITLE
Clarify the meaning of “ADC write pointer” in doxygen comment

### DIFF
--- a/rp-api/api/include/redpitaya/rp_acq.h
+++ b/rp-api/api/include/redpitaya/rp_acq.h
@@ -291,6 +291,11 @@ int rp_AcqGetGainV(rp_channel_t channel, float* voltage);
 
 /**
  * Returns current position of ADC write pointer.
+ *
+ * The write pointer position is the index, within the ADC buffer, of the last
+ * array cell that has been written to.
+ * @note The ADC buffer is a ring buffer. When it is full, the index of the oldest ADC sample is  
+ *     `(write_pointer_position + 1) % ADC_BUFFER_SIZE`
  * @param pos Write pointer position
  * @return If the function is successful, the return value is RP_OK.
  * If the function is unsuccessful, the return value is any of RP_E* values that indicate an error.


### PR DESCRIPTION
The documented purpose of `rp_AcqGetWritePointer()` is simply:

> Returns current position of ADC write pointer.

This is ambiguous. Contrary to what one would do in idiomatic C, this position is recorded as the index of the last cell that has been written to, rather than the index of the cell immediately after.

This pull request clarifies what the library means by “ADC write pointer”.
