### PR TITLE
Streaming Manager - Decimation NaN bug

### DIFF
--- a/apps-tools/streaming_manager/js/rate_limitator.js
+++ b/apps-tools/streaming_manager/js/rate_limitator.js
@@ -86,8 +86,8 @@
                 }
                 if (SM.first_run_net) {
                     SM.first_run_net = false;
-                    rate = SM.ss_full_rate / default_devider_net;
-                    rate_devider = default_devider_net;
+                    // rate = SM.ss_full_rate / default_devider_net;
+                    // rate_devider = default_devider_net;
                 }
             } else {
                 if (channel_mode != 3) {
@@ -99,8 +99,8 @@
                 }
                 if (SM.first_run_sd) {
                     SM.first_run_sd = false;
-                    rate = SM.ss_full_rate / default_devider_sd;
-                    rate_devider = default_devider_sd;
+                    // rate = SM.ss_full_rate / default_devider_sd;
+                    // rate_devider = default_devider_sd;
                 }
             }
 
@@ -122,8 +122,8 @@
                 }
                 if (SM.first_run_net) {
                     SM.first_run_net = false;
-                    rate = SM.ss_full_rate / default_devider_net;
-                    rate_devider = default_devider_net;
+                    // rate = SM.ss_full_rate / default_devider_net;
+                    // rate_devider = default_devider_net;
                 }
             } else {
                 if (channel_mode != 3) {
@@ -135,8 +135,8 @@
                 }
                 if (SM.first_run_sd) {
                     SM.first_run_sd = false;
-                    rate = SM.ss_full_rate / default_devider_sd;
-                    rate_devider = default_devider_sd;
+                    // rate = SM.ss_full_rate / default_devider_sd;
+                    // rate_devider = default_devider_sd;
                 }
             }
 
@@ -158,8 +158,8 @@
                 }
                 if (SM.first_run_net) {
                     SM.first_run_net = false;
-                    rate = SM.ss_full_rate / default_devider_net;
-                    rate_devider = default_devider_net;
+                    // rate = SM.ss_full_rate / default_devider_net;
+                    // rate_devider = default_devider_net;
                 }
             } else {
                 if (channel_mode != 3) {
@@ -171,8 +171,8 @@
                 }
                 if (SM.first_run_sd) {
                     SM.first_run_sd = false;
-                    rate = SM.ss_full_rate / default_devider_sd;
-                    rate_devider = default_devider_sd;
+                    // rate = SM.ss_full_rate / default_devider_sd;
+                    // rate_devider = default_devider_sd;
                 }
             }
         }


### PR DESCRIPTION
In the Streaming Manager web application, entering a sample rate will (imo) incorrectly feed back into the "SM.ss_max_rate" and "SM.ss_max_rate_devider" variables when "SM.first_run_sd" is true. This causes the web interface to refuse requests whch specify a higher sample rate than what it began with, rejecting the request with "NaN Mhz" and refusing to change the decimation.

This change modifies this behaviour, so the SM.ss_max_rate and SM.ss_max_rate_devider variables are set according to board model.