### PR TITLE
rp-api: use -1 instead of 0 as an invalid file descriptor

### DIFF
--- a/rp-api/api/src/common.c
+++ b/rp-api/api/src/common.c
@@ -21,13 +21,13 @@
 #include "common.h"
 #include "rp.h"
 
-int fd = 0;
+int fd = -1;
 
 bool g_DebugReg = false;
 
 int cmn_Init()
 {
-    if (!fd) {
+    if (fd == -1) {
         if((fd = open("/dev/uio/api", O_RDWR | O_SYNC)) == -1) {
             return RP_EOMD;
         }
@@ -37,12 +37,12 @@ int cmn_Init()
 
 int cmn_Release()
 {
-    if (fd) {
+    if (fd != -1) {
         if(close(fd) < 0) {
             return RP_ECMD;
         }
     }
-    fd = 0;
+    fd = -1;
     return RP_OK;
 }
 


### PR DESCRIPTION
In [rp-api/api/src/common.c][1], the file descriptor for the uio device may have the value 0, which is interpreted as meaning “invalid” or “not initialized”. This is problematic for three reasons:

1. The value 0 is a perfectly legitimate file descriptor. In fact, if the user closes `stdin` before calling `rp_Init()`, the uio file descriptor will indeed be set to zero.

2. If opening the uio device fails, the file descriptor will be assigned the value -1. This value then has to be interpreted as “invalid”.

3. The functions `cmn_Map()` and `cmn_Unmap()` already use -1 to mean “invalid”.

This pull request makes `-1` the value that represents an “invalid” file descriptor.

[1]: ../blob/master/rp-api/api/src/common.c