### PR TITLE
Print error descriptions instead of error numbers

### DIFF
--- a/rp-api/api-hw-profiles/src/common.cpp
+++ b/rp-api/api-hw-profiles/src/common.cpp
@@ -325,7 +325,7 @@ int hp_cmn_Init() {
 
     std::ifstream eeprom("/sys/bus/i2c/devices/0-0050/eeprom", std::ios::binary);
     if (!eeprom.is_open()) {
-        fprintf(stderr, "[hp_cmn_Init] Error open eeprom: %d\n", errno);
+        fprintf(stderr, "[hp_cmn_Init] Error open eeprom: %s\n", strerror(errno));
         return RP_HP_ERE;
     }
 

--- a/rp-api/api-hw/src/uart.c
+++ b/rp-api/api-hw/src/uart.c
@@ -219,7 +219,7 @@ int uart_read(unsigned char *_buffer, int *size)
                 }
                 else
                 {
-                    ERROR_LOG("Error read from UART. Errno: %d", errno);
+                    ERROR_LOG("Error read from UART. Errno: %s", strerror(errno));
                     return RP_HW_ERU;
                 }
             }

--- a/rp-api/api/src/axi_manager.cpp
+++ b/rp-api/api/src/axi_manager.cpp
@@ -67,7 +67,7 @@ int osc_axi_map(size_t size, size_t offset, void** mapped) {
     }
     *mapped = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, g_mem_fd, offset);
     if (*mapped == MAP_FAILED) {
-        ERROR_LOG("Error osc_axi_map: %d\n", errno);
+        ERROR_LOG("Error osc_axi_map: %s\n", strerror(errno));
         return RP_EMMD;
     }
     return RP_OK;


### PR DESCRIPTION
The C API [can sometimes print cryptic error messages][err] such as:

```text
[hp_cmn_Init] Error open eeprom: 13
```

This pull request makes the error-codes human-readable (“Permission denied” instead of “13”) by wrapping them in calls to `strerror()`.

[err]: ../../ubuntu/pull/4