### PR TITLE
rp-api: only open /dev/mem if needed

### DIFF
--- a/rp-api/api/src/oscilloscope.c
+++ b/rp-api/api/src/oscilloscope.c
@@ -77,14 +77,6 @@ int osc_Init(int channels)
     osc_cha = (uint32_t*)((char*)osc_reg + OSC_CHA_OFFSET);
     osc_chb = (uint32_t*)((char*)osc_reg + OSC_CHB_OFFSET);
 
-    if (mem_fd == -1) {
-        mem_fd = open("/dev/mem", O_RDWR | O_SYNC);
-        if (mem_fd < 0) {
-            return RP_EOMD;
-        }
-    }
-
-
     if (channels == 4){
         size_t base_addr = OSC_BASE_ADDR_4CH;
         ECHECK(cmn_Map(OSC_BASE_SIZE, base_addr, (void**)&osc_reg_4ch))
@@ -946,10 +938,6 @@ const volatile uint32_t* osc_GetDataBufferChD()
 
 int osc_axi_map(size_t size, size_t offset, void** mapped, uint32_t *mapped_size)
 {
-    if (mem_fd == -1) {
-        return RP_EMMD;
-    }
-
     if (offset < g_adc_axi_start) {
         return RP_EOOR;
     }
@@ -961,6 +949,13 @@ int osc_axi_map(size_t size, size_t offset, void** mapped, uint32_t *mapped_size
     if (offset % sysconf(_SC_PAGESIZE) != 0) {
         ERROR("Error size. offset %% sysconf(_SC_PAGESIZE) = %ld  must be zero. sysconf(_SC_PAGESIZE) = %ld\n",offset % sysconf(_SC_PAGESIZE),sysconf(_SC_PAGESIZE));
         return RP_EMMD;
+    }
+
+    if (mem_fd == -1) {
+        mem_fd = open("/dev/mem", O_RDWR | O_SYNC);
+        if (mem_fd < 0) {
+            return RP_EOMD;
+        }
     }
 
     *mapped = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, mem_fd, offset);


### PR DESCRIPTION
[Deep Memory Acquisition (DMA)][dma] uses /dev/mem for accessing the memory that has been [reserved for this purpose][reserved]. This is the only way in which /dev/mem is ever used: no API function, outside of DMA, has any use of /dev/mem.

However, `rp_Init()` (via `osc_Init()`) unconditionally opens /dev/mem. This is unfortunate, as it effectively forces the program to run under the identity of root. Giving the user read/write access to /dev/mem is not enough, as this special file can only be accessed by [processes having the `CAP_SYS_RAWIO` capability][rawio] (i.e. root-owned processes, bar [setcap][]).

This pull request fixes this issue by only opening /dev/mem when needed. Programs that do not use DMA (including those that use the [regular acquisition functions][acq]) can run without root privileges.

With this change, in the public API, only `rp_AcqAxiEnable()` causes /dev/mem to be opened, via `osc_axi_EnableCh*()` and `osc_axi_map()`. The latter is responsible for both opening and memory-mapping the file.

**Note**: The first commit here fixes the incorrect use of zero as an invalid file descriptor. This is similar to the fix of #296. I can, upon request, split it into a separate pull request.

[dma]: https://redpitaya.readthedocs.io/en/latest/appsFeatures/remoteControl/command_list.html#deep-memory-acquisition-dma
[reserved]: ../../RedPitaya-FPGA/blob/2.00-37/dts/memory.dtsi#L22-L24
[rawio]: https://elixir.bootlin.com/linux/v6.10/source/drivers/char/mem.c#L609
[setcap]: https://man7.org/linux/man-pages/man8/setcap.8.html
[acq]: https://redpitaya.readthedocs.io/en/latest/appsFeatures/remoteControl/command_list.html#acquisition
