### PR TITLE
More robust handling of fscanf() failures

### DIFF
--- a/rp-api/api-hw/src/sensors.c
+++ b/rp-api/api-hw/src/sensors.c
@@ -12,7 +12,7 @@ int sens_GetValueFromFile(const char* file, uint32_t *value){
 		return -1;
 	}
     int rv = 0;
-    int r = !fscanf (fp, "%d", &rv);
+    int r = fscanf (fp, "%d", &rv) != 1;
     *value = rv;
     fclose(fp);
     return r;
@@ -25,7 +25,7 @@ int sens_GetFValueFromFile(const char* file, float *value){
 		ERROR("Can't open %s",file);
 		return -1;
 	}
-    float r = !fscanf (fp, "%f", value);
+    float r = fscanf (fp, "%f", value) != 1;
     fclose(fp);
     return r;
 }
@@ -70,7 +70,7 @@ int AI4pinGetValueRaw(uint32_t* value) {
         ERROR("Can't open %s","/sys/devices/soc0/axi/83c00000.xadc_wiz/iio:device1/in_voltage12_raw");
         return -1;
     }
-    int r = !fscanf (fp, "%u", value);
+    int r = fscanf (fp, "%u", value) != 1;
     fclose(fp);
     return r;
 }


### PR DESCRIPTION
There are three instances in rp-api/api-hw/src/sensors.c where an error code `r` is assigned like this:

```c
int r = !fscanf (fp, "%d", &rv);
```

This assumes that this call to [`fscanf()`][man] can only return 0 (on failure) or 1 (on success). However, in case of failure, `fscanf()` can return either 0 or `EOF` (typically -1), depending on the exact nature of the failure.

This pull request makes the code more robust against failures by assuming success only when `fscanf()` returns 1.

[man]: https://man7.org/linux/man-pages/man3/fscanf.3.html