### PR TITLE
Fix Doxygen comment on rp_GetCPUTemperature()

### DIFF
--- a/rp-api/api-hw/include/rp_hw.h
+++ b/rp-api/api-hw/include/rp_hw.h
@@ -670,8 +670,8 @@ int rp_I2C_IOCTL_WriteBuffer(uint8_t *buffer, int len);
 
 /**
  * Returns the current CPU temperature
- * @return If the function is successful, the return non
- * If the function is unsuccessful, the return value is any of RP_HW_E* values that indicate an error.
+ * @return If the function is successful, return the CPU temperature.
+ * If the function is unsuccessful, return (float) -1.
  */
 float rp_GetCPUTemperature(uint32_t *raw);
 


### PR DESCRIPTION
From the commit log:

> The sentence “If the function is successful, the return non” is not finished: let's finish it.
>
> The sentence "If the function is unsuccessful, the return value is any of RP\_HW\_E\* values that indicate an error" is incorrect: in case of error, (float) -1 is returned. Fix that.

A couple of side notes:
* It would be nice to specify the temperature unit. Is it °C?
* On a cold environment, I would expect `-1.0f` to be a valid temperature reading. For conveying the meaning of “invalid reading”, `NAN` would be more appropriate.
