### PR TITLE
Remove “this is C code” comments

### DIFF
--- a/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/include/http.h
+++ b/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/include/http.h
@@ -6,10 +6,6 @@
  * @Author Ales Bardorfer <ales.bardorfer@redpitaya.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef REDPITAYA_HTTP_H

--- a/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/include/ngx_http_rp_module.h
+++ b/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/include/ngx_http_rp_module.h
@@ -6,10 +6,6 @@
  * @Author Jure Menart <juremenart@gmail.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __NGX_HTTP_RP_MODULE_H

--- a/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/include/rp_bazaar_app.h
+++ b/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/include/rp_bazaar_app.h
@@ -6,10 +6,6 @@
  * @Author Jure Menart <juremenart@gmail.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_BAZAAR_APP_H

--- a/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/include/rp_bazaar_cmd.h
+++ b/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/include/rp_bazaar_cmd.h
@@ -6,10 +6,6 @@
  * @Author Jure Menart <juremenart@gmail.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_BAZAAR_CMD_H

--- a/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/include/rp_data_cmd.h
+++ b/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/include/rp_data_cmd.h
@@ -6,10 +6,6 @@
  * @Author Jure Menart <juremenart@gmail.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_DATA_CMD_H

--- a/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/src/http.c
+++ b/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/src/http.c
@@ -6,10 +6,6 @@
  * @Author Ales Bardorfer <ales.bardorfer@redpitaya.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdlib.h>

--- a/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/src/ngx_http_rp_module.c
+++ b/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/src/ngx_http_rp_module.c
@@ -6,10 +6,6 @@
  * @Author Jure Menart <juremenart@gmail.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <ngx_config.h>

--- a/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/src/rp_bazaar_app.c
+++ b/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/src/rp_bazaar_app.c
@@ -7,10 +7,6 @@
  *         Ales Bardorfer <ales.bardorfer@redpitaya.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/src/rp_bazaar_cmd.c
+++ b/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/src/rp_bazaar_cmd.c
@@ -7,10 +7,6 @@
  *         Ales Bardorfer <ales.bardorfer@redpitaya.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <ngx_config.h>

--- a/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/src/rp_data_cmd.c
+++ b/Bazaar/nginx/ngx_ext_modules/ngx_http_rp_module/src/rp_data_cmd.c
@@ -6,10 +6,6 @@
  * @Author Jure Menart <juremenart@gmail.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <ngx_config.h>

--- a/Test/acquire/src/acquire.cpp
+++ b/Test/acquire/src/acquire.cpp
@@ -3,10 +3,6 @@
  * @brief Red Pitaya simple signal acquisition utility.
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <getopt.h>

--- a/Test/acquire_p/src/acquire.cpp
+++ b/Test/acquire_p/src/acquire.cpp
@@ -3,10 +3,6 @@
  * @brief Red Pitaya simple signal acquisition utility.
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <getopt.h>

--- a/Test/bode/src/bode.cpp
+++ b/Test/bode/src/bode.cpp
@@ -16,10 +16,6 @@
  * Data analysis returns frequency, phase and amplitude.
  *
  * VERSION: VERSION defined in Makefile
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <complex.h>

--- a/Test/calib/src/calib.cpp
+++ b/Test/calib/src/calib.cpp
@@ -5,10 +5,6 @@
  *
 
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/Test/calib/src/rp_eeprom.cpp
+++ b/Test/calib/src/rp_eeprom.cpp
@@ -7,10 +7,6 @@
  *         Ales Bardorfer <ales.bardorfer@redpitaya.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <errno.h>

--- a/Test/calib/src/rp_eeprom.h
+++ b/Test/calib/src/rp_eeprom.h
@@ -7,10 +7,6 @@
  *         Ales Bardorfer <ales.bardorfer@redpitaya.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_EEPROM_H

--- a/Test/daisy_tool/src/main.cpp
+++ b/Test/daisy_tool/src/main.cpp
@@ -5,10 +5,6 @@
  *
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/Test/filter_calib/src/main.cpp
+++ b/Test/filter_calib/src/main.cpp
@@ -3,10 +3,6 @@
  * @brief Red Pitaya filter calib utility.
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <getopt.h>

--- a/Test/led_control/src/main.cpp
+++ b/Test/led_control/src/main.cpp
@@ -5,10 +5,6 @@
  *
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/Test/monitor/src/monitor.cpp
+++ b/Test/monitor/src/monitor.cpp
@@ -6,10 +6,6 @@
  * @Author Crt Valentincic <crt.valentincic@redpitaya.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef _GNU_SOURCE

--- a/Test/profiles/src/main.cpp
+++ b/Test/profiles/src/main.cpp
@@ -5,10 +5,6 @@
  *
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <errno.h>

--- a/Test/scpi-client/main.c
+++ b/Test/scpi-client/main.c
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 

--- a/Test/updater/src/main.cpp
+++ b/Test/updater/src/main.cpp
@@ -3,10 +3,6 @@
  * @brief Red Pitaya updater utility.
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <getopt.h>

--- a/apps-tools/arb_manager/src/version.h
+++ b/apps-tools/arb_manager/src/version.h
@@ -6,10 +6,6 @@
  *
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef VERSION_H

--- a/apps-tools/spectrumpro/src/rp_math.h
+++ b/apps-tools/spectrumpro/src/rp_math.h
@@ -4,10 +4,6 @@
  * @brief Red Pitaya Spectrum Analyzer DSC processing.
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_MATH_H__

--- a/apps-tools/streaming_manager/src/streaming-server/src/main.cpp
+++ b/apps-tools/streaming_manager/src/streaming-server/src/main.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdbool.h>

--- a/rp-api/api-app/lcr_meter/src/calib.cpp
+++ b/rp-api/api-app/lcr_meter/src/calib.cpp
@@ -6,10 +6,6 @@
 * @Author Luka Golinar <luka.golinar@gmail.com>
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 
 #include <stdio.h>

--- a/rp-api/api-app/lcr_meter/src/calib.h
+++ b/rp-api/api-app/lcr_meter/src/calib.h
@@ -6,10 +6,6 @@
 * @Author Luka Golinar <luka.golinar@gmail.com>
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 
 #ifndef __CALIB_H

--- a/rp-api/api-app/lcr_meter/src/lcrApp.cpp
+++ b/rp-api/api-app/lcr_meter/src/lcrApp.cpp
@@ -6,10 +6,6 @@
 * @Author Luka Golinar <luka.golinar@redpitaya.com>
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 
 #include <stdio.h>

--- a/rp-api/api-app/lcr_meter/src/lcrApp.h
+++ b/rp-api/api-app/lcr_meter/src/lcrApp.h
@@ -6,10 +6,6 @@
 * @Author Luka Golinar
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 
 #ifndef __LCR_APP_H

--- a/rp-api/api-app/lcr_meter/src/lcr_generator.cpp
+++ b/rp-api/api-app/lcr_meter/src/lcr_generator.cpp
@@ -6,10 +6,6 @@
 * @Author Luka Golinar <luka.golinar@gmail.com>
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 
 #include <complex.h>

--- a/rp-api/api-app/lcr_meter/src/lcr_generator.h
+++ b/rp-api/api-app/lcr_meter/src/lcr_generator.h
@@ -6,10 +6,6 @@
 * @Author Luka Golinar <luka.golinar@gmail.com>
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 
 #ifndef __LCRGENERATOR_H

--- a/rp-api/api-app/lcr_meter/src/lcr_hw.cpp
+++ b/rp-api/api-app/lcr_meter/src/lcr_hw.cpp
@@ -6,10 +6,6 @@
 * @Author Luka Golinar <luka.golinar@gmail.com>
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 
 #include <complex.h>

--- a/rp-api/api-app/lcr_meter/src/lcr_hw.h
+++ b/rp-api/api-app/lcr_meter/src/lcr_hw.h
@@ -6,10 +6,6 @@
 * @Author Luka Golinar <luka.golinar@gmail.com>
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 
 #ifndef __LCRHARDWARE_H

--- a/rp-api/api-app/lcr_meter/src/lcr_meter.cpp
+++ b/rp-api/api-app/lcr_meter/src/lcr_meter.cpp
@@ -7,10 +7,6 @@
 * @Author Luka Golinar <luka.golinar@gmail.com>
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 
 #include <complex.h>

--- a/rp-api/api-app/lcr_meter/src/lcr_meter.h
+++ b/rp-api/api-app/lcr_meter/src/lcr_meter.h
@@ -6,10 +6,6 @@
 * @Author Luka Golinar <luka.golinar@gmail.com>
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 
 #ifndef __LCRMETER_H

--- a/rp-api/api-app/lcr_meter/src/utils.cpp
+++ b/rp-api/api-app/lcr_meter/src/utils.cpp
@@ -6,10 +6,6 @@
  * @Author Luka Golinar, RedPitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- */
 
 #include <fcntl.h>
 #include <stdio.h>

--- a/rp-api/api-app/lcr_meter/src/utils.h
+++ b/rp-api/api-app/lcr_meter/src/utils.h
@@ -6,10 +6,6 @@
  * @Author Luka Golinar, RedPitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
  #ifndef UTILS_H_

--- a/rp-api/api-app/src/bodeApp.cpp
+++ b/rp-api/api-app/src/bodeApp.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 #include "bodeApp.h"
 #include <complex.h>

--- a/rp-api/api-app/src/bodeApp.h
+++ b/rp-api/api-app/src/bodeApp.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __BODE_API_H

--- a/rp-api/api-app/src/common.cpp
+++ b/rp-api/api-app/src/common.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 

--- a/rp-api/api-app/src/common.h
+++ b/rp-api/api-app/src/common.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef COMMON_APP_H_

--- a/rp-api/api-app/src/osciloscopeApp.cpp
+++ b/rp-api/api-app/src/osciloscopeApp.cpp
@@ -6,10 +6,6 @@
 * @Author Red Pitaya
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE

--- a/rp-api/api-app/src/osciloscopeApp.h
+++ b/rp-api/api-app/src/osciloscopeApp.h
@@ -6,10 +6,6 @@
 * @Author Red Pitaya
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 
 #ifndef __OSCILOSCOPE_H

--- a/rp-api/api-app/src/rpApp.cpp
+++ b/rp-api/api-app/src/rpApp.cpp
@@ -6,10 +6,6 @@
 * @Author Red Pitaya
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 
 #include <stdint.h>

--- a/rp-api/api-app/src/rpApp.h
+++ b/rp-api/api-app/src/rpApp.h
@@ -7,10 +7,6 @@
 * @Author Red Pitaya
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 
 #ifndef __RP_APP_H

--- a/rp-api/api-app/src/spectrometerApp.cpp
+++ b/rp-api/api-app/src/spectrometerApp.cpp
@@ -6,10 +6,6 @@
  * @Author Jure Menart <juremenart@gmail.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE

--- a/rp-api/api-app/src/spectrometerApp.h
+++ b/rp-api/api-app/src/spectrometerApp.h
@@ -6,10 +6,6 @@
  * @Author Jure Menart <juremenart@gmail.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __SPECTROMETERAPP_H

--- a/rp-api/api-arb/src/rp_arb.cpp
+++ b/rp-api/api-arb/src/rp_arb.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "rp_arb.h"

--- a/rp-api/api-arb/src/rp_arb.h
+++ b/rp-api/api-arb/src/rp_arb.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __ARB_API_H

--- a/rp-api/api-arb/src/rp_coe.cpp
+++ b/rp-api/api-arb/src/rp_coe.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "rp_coe.h"

--- a/rp-api/api-arb/src/rp_coe.h
+++ b/rp-api/api-arb/src/rp_coe.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __ARB_COE_API_H

--- a/rp-api/api-dsp/src/rp_algorithms.h
+++ b/rp-api/api-dsp/src/rp_algorithms.h
@@ -4,10 +4,6 @@
  * @brief Red Pitaya Spectrum Analyzer DSP processing.
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 

--- a/rp-api/api-dsp/src/rp_dsp.cpp
+++ b/rp-api/api-dsp/src/rp_dsp.cpp
@@ -6,10 +6,6 @@
  * @Author Jure Menart <juremenart@gmail.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <errno.h>

--- a/rp-api/api-dsp/src/rp_dsp.h
+++ b/rp-api/api-dsp/src/rp_dsp.h
@@ -4,10 +4,6 @@
  * @brief Red Pitaya Spectrum Analyzer DSC processing.
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_DSP_H__

--- a/rp-api/api-dsp/src/rp_math.h
+++ b/rp-api/api-dsp/src/rp_math.h
@@ -4,10 +4,6 @@
  * @brief Red Pitaya Spectrum Analyzer DSC processing.
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_MATH_H__

--- a/rp-api/api-formatter/src/rp_formatter.h
+++ b/rp-api/api-formatter/src/rp_formatter.h
@@ -4,10 +4,6 @@
  * @brief Red Pitaya data formatter.
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_FORMATTER_H__

--- a/rp-api/api-formatter/src/writers/rp_csv_writer.h
+++ b/rp-api/api-formatter/src/writers/rp_csv_writer.h
@@ -4,10 +4,6 @@
  * @brief Red Pitaya data formatter.
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_CSV_H__

--- a/rp-api/api-formatter/src/writers/rp_tdms_writer.h
+++ b/rp-api/api-formatter/src/writers/rp_tdms_writer.h
@@ -4,10 +4,6 @@
  * @brief Red Pitaya data formatter.
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_TDMS_H__

--- a/rp-api/api-formatter/src/writers/rp_wav_writer.h
+++ b/rp-api/api-formatter/src/writers/rp_wav_writer.h
@@ -4,10 +4,6 @@
  * @brief Red Pitaya data formatter.
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_WAV_H__

--- a/rp-api/api-hw-calib/src/calib.cpp
+++ b/rp-api/api-hw-calib/src/calib.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "calib.h"

--- a/rp-api/api-hw-calib/src/calib.h
+++ b/rp-api/api-hw-calib/src/calib.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __CALIB_H

--- a/rp-api/api-hw-calib/src/calib_common.h
+++ b/rp-api/api-hw-calib/src/calib_common.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __CALIB_COMMON_H

--- a/rp-api/api-hw-calib/src/calib_structs.h
+++ b/rp-api/api-hw-calib/src/calib_structs.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_HW_CALIB_STRUCT_H

--- a/rp-api/api-hw-calib/src/calib_universal.h
+++ b/rp-api/api-hw-calib/src/calib_universal.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_HW_CALIB_UNIVERSAL_H

--- a/rp-api/api-hw-calib/src/rp_hw_calib.cpp
+++ b/rp-api/api-hw-calib/src/rp_hw_calib.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdint.h>

--- a/rp-api/api-hw-calib/src/rp_log.h
+++ b/rp-api/api-hw-calib/src/rp_log.h
@@ -2,10 +2,6 @@
  * $Id: $
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef RP_LOG_H

--- a/rp-api/api-hw-can/src/can_control.h
+++ b/rp-api/api-hw-can/src/can_control.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef CAN_CONTROL_H

--- a/rp-api/api-hw-can/src/can_socket.h
+++ b/rp-api/api-hw-can/src/can_socket.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef _CAN_SOCKET_H_

--- a/rp-api/api-hw-can/src/rp_hw_can.cpp
+++ b/rp-api/api-hw-can/src/rp_hw_can.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/rp-api/api-hw-profiles/include/rp_hw-profiles.h
+++ b/rp-api/api-hw-profiles/include/rp_hw-profiles.h
@@ -7,10 +7,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef RP_HW_PROFILES_H

--- a/rp-api/api-hw-profiles/src/common.cpp
+++ b/rp-api/api-hw-profiles/src/common.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/common.h
+++ b/rp-api/api-hw-profiles/src/common.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef RP_HW_PROFILES_COMMON_H

--- a/rp-api/api-hw-profiles/src/stem_122_16SDR_v1.0.h
+++ b/rp-api/api-hw-profiles/src/stem_122_16SDR_v1.0.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_122_16SDR_v1.1.h
+++ b/rp-api/api-hw-profiles/src/stem_122_16SDR_v1.1.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_10_v1.0.h
+++ b/rp-api/api-hw-profiles/src/stem_125_10_v1.0.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_LN_BO_v1.1.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_LN_BO_v1.1.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_LN_CE1_v1.1.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_LN_CE1_v1.1.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_LN_CE2_v1.1.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_LN_CE2_v1.1.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_LN_v1.1.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_LN_v1.1.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_Pro_v2.0.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_Pro_v2.0.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_Z7020_4IN_BO_v1.3.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_Z7020_4IN_BO_v1.3.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_Z7020_4IN_v1.0.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_Z7020_4IN_v1.0.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_Z7020_4IN_v1.2.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_Z7020_4IN_v1.2.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_Z7020_4IN_v1.3.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_Z7020_4IN_v1.3.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_Z7020_Ind_v2.0.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_Z7020_Ind_v2.0.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_Z7020_LL_v1.1.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_Z7020_LL_v1.1.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_Z7020_LL_v1.2.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_Z7020_LL_v1.2.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_Z7020_LN_v1.1.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_Z7020_LN_v1.1.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_Z7020_Pro_v1.0.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_Z7020_Pro_v1.0.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_Z7020_Pro_v2.0.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_Z7020_Pro_v2.0.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_Z7020_TI_v1.3.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_Z7020_TI_v1.3.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_Z7020_v1.0.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_Z7020_v1.0.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_v1.0.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_v1.0.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_v1.1.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_v1.1.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_125_14_v2.0.h
+++ b/rp-api/api-hw-profiles/src/stem_125_14_v2.0.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_250_12_120.h
+++ b/rp-api/api-hw-profiles/src/stem_250_12_120.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_250_12_v1.0.h
+++ b/rp-api/api-hw-profiles/src/stem_250_12_v1.0.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_250_12_v1.1.h
+++ b/rp-api/api-hw-profiles/src/stem_250_12_v1.1.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_250_12_v1.2.h
+++ b/rp-api/api-hw-profiles/src/stem_250_12_v1.2.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_250_12_v1.2a.h
+++ b/rp-api/api-hw-profiles/src/stem_250_12_v1.2a.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_250_12_v1.2b.h
+++ b/rp-api/api-hw-profiles/src/stem_250_12_v1.2b.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_65_16_Z7020_LL_v1.1.h
+++ b/rp-api/api-hw-profiles/src/stem_65_16_Z7020_LL_v1.1.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_65_16_Z7020_TI_v1.3.h
+++ b/rp-api/api-hw-profiles/src/stem_65_16_Z7020_TI_v1.3.h
@@ -8,10 +8,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw-profiles/src/stem_special.h
+++ b/rp-api/api-hw-profiles/src/stem_special.h
@@ -7,10 +7,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api-hw/include/rp_hw.h
+++ b/rp-api/api-hw/include/rp_hw.h
@@ -7,10 +7,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef RP_HW_H

--- a/rp-api/api-hw/src/i2c-helper.h
+++ b/rp-api/api-hw/src/i2c-helper.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __I2C_HELPER_H

--- a/rp-api/api-hw/src/i2c.c
+++ b/rp-api/api-hw/src/i2c.c
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/rp-api/api-hw/src/i2c.h
+++ b/rp-api/api-hw/src/i2c.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __I2C_H

--- a/rp-api/api-hw/src/led_system.c
+++ b/rp-api/api-hw/src/led_system.c
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #define _GNU_SOURCE

--- a/rp-api/api-hw/src/led_system.h
+++ b/rp-api/api-hw/src/led_system.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef LED_SYSTEM_H

--- a/rp-api/api-hw/src/rp_hw.c
+++ b/rp-api/api-hw/src/rp_hw.c
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/rp-api/api-hw/src/rp_log.h
+++ b/rp-api/api-hw/src/rp_log.h
@@ -2,10 +2,6 @@
  * $Id: $
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef RP_LOG_H

--- a/rp-api/api-hw/src/sensors.h
+++ b/rp-api/api-hw/src/sensors.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef SENSORS_H

--- a/rp-api/api-hw/src/spi-helper.h
+++ b/rp-api/api-hw/src/spi-helper.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef SPI_HELPER_H

--- a/rp-api/api-hw/src/spi.c
+++ b/rp-api/api-hw/src/spi.c
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdint.h>

--- a/rp-api/api-hw/src/spi.h
+++ b/rp-api/api-hw/src/spi.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __SPI_H

--- a/rp-api/api-hw/src/uart.c
+++ b/rp-api/api-hw/src/uart.c
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 #define _BSD_SOURCE
 #define _DEFAULT_SOURCE

--- a/rp-api/api-hw/src/uart.h
+++ b/rp-api/api-hw/src/uart.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __UART_H

--- a/rp-api/api-la/src/bit_decoder/bit_decoder.h
+++ b/rp-api/api-la/src/bit_decoder/bit_decoder.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __BIT_DECODER_API_H

--- a/rp-api/api-la/src/common/common.h
+++ b/rp-api/api-la/src/common/common.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_LA_COMMON_H

--- a/rp-api/api-la/src/common/dma.h
+++ b/rp-api/api-la/src/common/dma.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_LA_DMA_H

--- a/rp-api/api-la/src/common/structs.h
+++ b/rp-api/api-la/src/common/structs.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_LA_STRUCTS_H

--- a/rp-api/api-la/src/decoders/decoder.h
+++ b/rp-api/api-la/src/decoders/decoder.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __DECODER_API_H

--- a/rp-api/api-la/src/rp_la.cpp
+++ b/rp-api/api-la/src/rp_la.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "rp_la.h"

--- a/rp-api/api-la/src/rp_la.h
+++ b/rp-api/api-la/src/rp_la.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_LA_H

--- a/rp-api/api-la/src/rp_la_acq.cpp
+++ b/rp-api/api-la/src/rp_la_acq.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <fcntl.h>

--- a/rp-api/api-la/src/rp_la_acq.h
+++ b/rp-api/api-la/src/rp_la_acq.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 // For more information see: /doc/logic/README.md & la_top.sv

--- a/rp-api/api-sweep/src/rp_sweep.h
+++ b/rp-api/api-sweep/src/rp_sweep.h
@@ -4,10 +4,6 @@
  * @brief Red Pitaya Sweep controller.
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_SWEEP_H__

--- a/rp-api/api-updater/src/rp_log.h
+++ b/rp-api/api-updater/src/rp_log.h
@@ -2,10 +2,6 @@
  * $Id: $
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef RP_LOG_H

--- a/rp-api/api-updater/src/rp_updater.cpp
+++ b/rp-api/api-updater/src/rp_updater.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "rp_updater.h"

--- a/rp-api/api-updater/src/rp_updater.h
+++ b/rp-api/api-updater/src/rp_updater.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __UPDATER_API_H

--- a/rp-api/api-updater/src/rp_updater_common.cpp
+++ b/rp-api/api-updater/src/rp_updater_common.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "rp_updater_common.h"

--- a/rp-api/api-updater/src/rp_updater_common.h
+++ b/rp-api/api-updater/src/rp_updater_common.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __UPDATER_COMMON_API_H

--- a/rp-api/api-updater/src/rp_updater_curl.cpp
+++ b/rp-api/api-updater/src/rp_updater_curl.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "rp_updater_curl.h"

--- a/rp-api/api-updater/src/rp_updater_curl.h
+++ b/rp-api/api-updater/src/rp_updater_curl.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __UPDATER_CURL_API_H

--- a/rp-api/api-updater/src/rp_updater_fs.cpp
+++ b/rp-api/api-updater/src/rp_updater_fs.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "rp_updater_fs.h"

--- a/rp-api/api-updater/src/rp_updater_fs.h
+++ b/rp-api/api-updater/src/rp_updater_fs.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __UPDATER_FS_API_H

--- a/rp-api/api/include/common/rp_log.h
+++ b/rp-api/api/include/common/rp_log.h
@@ -2,10 +2,6 @@
  * $Id: $
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef RP_LOG_H

--- a/rp-api/api/include/common/version.h
+++ b/rp-api/api/include/common/version.h
@@ -7,10 +7,6 @@
  * @Author Ales Bardorfer <ales.bardorfer@redpitaya.com>
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef VERSION_H

--- a/rp-api/api/include/rp.h
+++ b/rp-api/api/include/rp.h
@@ -7,10 +7,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_H

--- a/rp-api/api/include/rp_acq.h
+++ b/rp-api/api/include/rp_acq.h
@@ -7,10 +7,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_ACQ_H

--- a/rp-api/api/include/rp_acq_axi.h
+++ b/rp-api/api/include/rp_acq_axi.h
@@ -7,10 +7,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_ACQ_AXI_H

--- a/rp-api/api/include/rp_asg_axi.h
+++ b/rp-api/api/include/rp_asg_axi.h
@@ -7,10 +7,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_ASG_AXI_H

--- a/rp-api/api/include/rp_enums.h
+++ b/rp-api/api/include/rp_enums.h
@@ -7,10 +7,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_ENUMS_H

--- a/rp-api/api/include/rp_gen.h
+++ b/rp-api/api/include/rp_gen.h
@@ -7,10 +7,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __RP_GEN_H

--- a/rp-api/api/src/acq_handler.cpp
+++ b/rp-api/api/src/acq_handler.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <assert.h>

--- a/rp-api/api/src/acq_handler.h
+++ b/rp-api/api/src/acq_handler.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef SRC_ACQ_HANDLER_H_

--- a/rp-api/api/src/analog_mixed_signals.h
+++ b/rp-api/api/src/analog_mixed_signals.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __ANALOG_MIXED_SIGNALS_H

--- a/rp-api/api/src/axi_manager.cpp
+++ b/rp-api/api/src/axi_manager.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "axi_manager.h"

--- a/rp-api/api/src/axi_manager.h
+++ b/rp-api/api/src/axi_manager.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef AXI_MANAGER_H

--- a/rp-api/api/src/common.cpp
+++ b/rp-api/api/src/common.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "common.h"

--- a/rp-api/api/src/common.h
+++ b/rp-api/api/src/common.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef COMMON_H_

--- a/rp-api/api/src/convert.hpp
+++ b/rp-api/api/src/convert.hpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef CONVERT_HPP_

--- a/rp-api/api/src/daisy.cpp
+++ b/rp-api/api/src/daisy.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "daisy.h"

--- a/rp-api/api/src/daisy.h
+++ b/rp-api/api/src/daisy.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __DAISY_H

--- a/rp-api/api/src/gen_handler.cpp
+++ b/rp-api/api/src/gen_handler.cpp
@@ -6,10 +6,6 @@
 * @Author Red Pitaya
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 
 #include "gen_handler.h"

--- a/rp-api/api/src/gen_handler.h
+++ b/rp-api/api/src/gen_handler.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef GENERATE_HANDLER_H_

--- a/rp-api/api/src/generate.cpp
+++ b/rp-api/api/src/generate.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include "generate.h"

--- a/rp-api/api/src/generate.h
+++ b/rp-api/api/src/generate.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 #ifndef __GENERATE_H
 #define __GENERATE_H

--- a/rp-api/api/src/housekeeping.cpp
+++ b/rp-api/api/src/housekeeping.cpp
@@ -6,10 +6,6 @@
 * @Author Red Pitaya
 *
 * (c) Red Pitaya  http://www.redpitaya.com
-*
-* This part of code is written in C programming language.
-* Please visit http://en.wikipedia.org/wiki/C_(programming_language)
-* for more details on the language used herein.
 */
 
 #include "housekeeping.h"

--- a/rp-api/api/src/housekeeping.h
+++ b/rp-api/api/src/housekeeping.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef __HOUSEKEEPING_H

--- a/rp-api/api/src/oscilloscope.cpp
+++ b/rp-api/api/src/oscilloscope.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <errno.h>

--- a/rp-api/api/src/oscilloscope.h
+++ b/rp-api/api/src/oscilloscope.h
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #ifndef SRC_OSCILLOSCOPE_H_

--- a/rp-api/api/src/rp.cpp
+++ b/rp-api/api/src/rp.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <pthread.h>

--- a/scpi-server/src/acquire.cpp
+++ b/scpi-server/src/acquire.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/scpi-server/src/acquire_axi.cpp
+++ b/scpi-server/src/acquire_axi.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/scpi-server/src/api_cmd.cpp
+++ b/scpi-server/src/api_cmd.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <fcntl.h>

--- a/scpi-server/src/apin.cpp
+++ b/scpi-server/src/apin.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/scpi-server/src/can.cpp
+++ b/scpi-server/src/can.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/scpi-server/src/common.cpp
+++ b/scpi-server/src/common.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <math.h>

--- a/scpi-server/src/dpin.cpp
+++ b/scpi-server/src/dpin.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/scpi-server/src/generate.cpp
+++ b/scpi-server/src/generate.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <math.h>

--- a/scpi-server/src/generate_axi.cpp
+++ b/scpi-server/src/generate_axi.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/scpi-server/src/i2c.cpp
+++ b/scpi-server/src/i2c.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/scpi-server/src/lcr.cpp
+++ b/scpi-server/src/lcr.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <math.h>

--- a/scpi-server/src/led.cpp
+++ b/scpi-server/src/led.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/scpi-server/src/main.cpp
+++ b/scpi-server/src/main.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdbool.h>

--- a/scpi-server/src/scpi-commands.cpp
+++ b/scpi-server/src/scpi-commands.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/scpi-server/src/scpi-parser-ext.cpp
+++ b/scpi-server/src/scpi-parser-ext.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <arpa/inet.h>

--- a/scpi-server/src/spi.cpp
+++ b/scpi-server/src/spi.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/scpi-server/src/sweep.cpp
+++ b/scpi-server/src/sweep.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <math.h>

--- a/scpi-server/src/uart.cpp
+++ b/scpi-server/src/uart.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <stdio.h>

--- a/scpi-server/src/uart_protocol.cpp
+++ b/scpi-server/src/uart_protocol.cpp
@@ -6,10 +6,6 @@
  * @Author Red Pitaya
  *
  * (c) Red Pitaya  http://www.redpitaya.com
- *
- * This part of code is written in C programming language.
- * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
- * for more details on the language used herein.
  */
 
 #include <errno.h>


### PR DESCRIPTION
Many source files contain, as part of their header boilerplate, this comment:

```c++
/*
 * This part of code is written in C programming language.
 * Please visit http://en.wikipedia.org/wiki/C_(programming_language)
 * for more details on the language used herein.
 */
```

This is both:
 * useless: if someone has to check Wikipedia to learn what C is, they are very unlikely to have any use of the source code
 * most often incorrect: most of this source code has been migrated to C++, while keeping the (now wrong) comment.

This pull request removes all those comments, save for the files in the `deprecated` directory.