### PR TITLE
rp-api: consistently use -1 as an invalid file descriptor

### DIFF
--- a/rp-api/api/src/axi_manager.cpp
+++ b/rp-api/api/src/axi_manager.cpp
@@ -114,12 +114,12 @@ int axi_releaseManager() {
         osc_axi_unmap(it.size, (void**)&it.mapped);
     }
     g_reserved.clear();
-    if (g_mem_fd) {
+    if (g_mem_fd != -1) {
         if (close(g_mem_fd) < 0) {
             return RP_ECMD;
         }
+        g_mem_fd = -1;
     }
-    g_mem_fd = -1;
     return RP_OK;
 }
 


### PR DESCRIPTION
axi_manager.cpp sets g_mem_fd to -1 to indicate the file descriptor is invalid. It should also compare it to -1 (rather that 0) when checking whether it is valid.