### PR TITLE
Fix typo: rp_InitAdressess -> rp_InitAddresses

### DIFF
--- a/rp-api/api-sweep/src/rp_sweep.cpp
+++ b/rp-api/api-sweep/src/rp_sweep.cpp
@@ -68,7 +68,7 @@ CSweepController::CSweepController() {
     m_pimpl->m_Pause = false;
     setDefault();
     if (!rp_IsApiInit()) {
-        if (rp_InitAdressess() == RP_OK) {
+        if (rp_InitAddresses() == RP_OK) {
             m_pimpl->apiInit = true;
         }
     }

--- a/rp-api/api/include/rp.h
+++ b/rp-api/api/include/rp.h
@@ -109,7 +109,7 @@
  * If the function is unsuccessful, the return value is any of RP_E* values that indicate an error.
  */
 
-int rp_InitAdressess();
+int rp_InitAddresses();
 
 /**
  * Initializes the library. It must be called first, before any other library method.

--- a/rp-api/api/src/rp.cpp
+++ b/rp-api/api/src/rp.cpp
@@ -48,7 +48,7 @@ std::mutex g_adioMutex;
  * Global methods
  */
 
-int rp_InitAdressess() {
+int rp_InitAddresses() {
     std::unique_lock lock(g_initMutex);
     if (g_api_state)
         return RP_EOOR;
@@ -101,7 +101,7 @@ int rp_InitAdressess() {
 
 int rp_Init() {
     if (!rp_IsApiInit()) {
-        ECHECK(rp_InitAdressess())
+        ECHECK(rp_InitAddresses())
     }
     int ret = rp_CalibInit();
     if (ret != RP_HP_OK) {
@@ -121,7 +121,7 @@ int rp_Init() {
 
 int rp_InitReset(bool reset) {
     if (!rp_IsApiInit()) {
-        ECHECK(rp_InitAdressess())
+        ECHECK(rp_InitAddresses())
     }
     if (reset) {
         int ret = rp_Reset();

--- a/rp-api/api/tests/rp_test_acq.py
+++ b/rp-api/api/tests/rp_test_acq.py
@@ -5,8 +5,8 @@ import time
 import numpy as np
 
 def init_rp():
-    print("rp.rp_InitAdressess()")
-    res = rp.rp_InitAdressess()
+    print("rp.rp_InitAddresses()")
+    res = rp.rp_InitAddresses()
     print(res)
 
     print("rp.rp_Init()")

--- a/rp-api/api/tests/rp_test_acq_axi.py
+++ b/rp-api/api/tests/rp_test_acq_axi.py
@@ -5,8 +5,8 @@ import time
 import numpy as np
 
 def init_rp():
-    print("rp.rp_InitAdressess()")
-    res = rp.rp_InitAdressess()
+    print("rp.rp_InitAddresses()")
+    res = rp.rp_InitAddresses()
     print(res)
 
     print("rp.rp_Init()")

--- a/rp-api/api/tests/rp_test_acq_split.py
+++ b/rp-api/api/tests/rp_test_acq_split.py
@@ -4,8 +4,8 @@ import rp
 import time
 
 def init_rp():
-    print("rp.rp_InitAdressess()")
-    res = rp.rp_InitAdressess()
+    print("rp.rp_InitAddresses()")
+    res = rp.rp_InitAddresses()
     print(res)
 
     print("rp.rp_Init()")

--- a/rp-api/api/tests/rp_test_analog.py
+++ b/rp-api/api/tests/rp_test_analog.py
@@ -3,8 +3,8 @@
 import rp
 
 def init_rp():
-    print("rp.rp_InitAdressess()")
-    res = rp.rp_InitAdressess()
+    print("rp.rp_InitAddresses()")
+    res = rp.rp_InitAddresses()
     print(res)
 
     print("rp.rp_Init()")

--- a/rp-api/api/tests/rp_test_gen.py
+++ b/rp-api/api/tests/rp_test_gen.py
@@ -4,8 +4,8 @@ import rp
 import numpy as np
 
 def init_rp():
-    print("rp.rp_InitAdressess()")
-    res = rp.rp_InitAdressess()
+    print("rp.rp_InitAddresses()")
+    res = rp.rp_InitAddresses()
     print(res)
 
     print("rp.rp_Init()")

--- a/rp-api/api/tests/rp_test_gen_axi.py
+++ b/rp-api/api/tests/rp_test_gen_axi.py
@@ -4,8 +4,8 @@ import rp
 import numpy as np
 
 def init_rp():
-    print("rp.rp_InitAdressess()")
-    res = rp.rp_InitAdressess()
+    print("rp.rp_InitAddresses()")
+    res = rp.rp_InitAddresses()
     print(res)
 
     print("rp.rp_Init()")

--- a/rp-api/api/tests/rp_test_hk.py
+++ b/rp-api/api/tests/rp_test_hk.py
@@ -5,8 +5,8 @@ import time
 import numpy as np
 
 def init_rp():
-    print("rp.rp_InitAdressess()")
-    res = rp.rp_InitAdressess()
+    print("rp.rp_InitAddresses()")
+    res = rp.rp_InitAddresses()
     print(res)
 
     print("rp.rp_Init()")


### PR DESCRIPTION
In an attempt to fix a typo, commit bd42e996e3c4 renamed `rp_InitAdresses()` → `rp_InitAdressess()`, adding an extra ‘s’ at the end. However, the correct spelling is “addresses” (double ‘d’, single final ‘s’).

This pull request sets the correct spelling.